### PR TITLE
Multi turn v2

### DIFF
--- a/askametric/query_processor/guardrails/guardrails.py
+++ b/askametric/query_processor/guardrails/guardrails.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import json
 from ...utils import _ask_llm_json
 from .guardrails_prompts import (
     create_relevance_prompt,
@@ -102,13 +101,9 @@ class MultiTurnLLMGuardrails(LLMGuardRails):
         """
         Handle the self-consistency of the query.
         """
-        prompt = create_self_consistency_prompt(query, language, script)
+        prompt = create_self_consistency_prompt(query)
         consistency_response = await _ask_llm_json(
-            prompt,
-            self.system_message,
-            self.guardrails_llm,
-            self.temperature,
-            context=json.dumps(chat_history),
+            prompt, self.system_message, self.guardrails_llm, self.temperature
         )
         self.consistent = consistency_response["answer"]["consistent"] == "True"
         if self.consistent is False:

--- a/askametric/query_processor/guardrails/guardrails_prompts.py
+++ b/askametric/query_processor/guardrails/guardrails_prompts.py
@@ -82,7 +82,7 @@ def create_self_consistency_prompt(query_text: str, language: str, script: str) 
     prompt = f"""
     I need to ensure that the user query is self-consistent.
     This means that the query should be understandable and unambiguous in the
-    context of the system prompt, and the chat history.
+    context the chat history -- remember only the semantic meaning of the query matters.
 
     Here is the user query:
     <<<{query_text}>>>

--- a/askametric/query_processor/guardrails/guardrails_prompts.py
+++ b/askametric/query_processor/guardrails/guardrails_prompts.py
@@ -72,3 +72,30 @@ def create_relevance_prompt(
     """
 
     return prompt
+
+
+def create_self_consistency_prompt(query_text: str, language: str, script: str) -> str:
+    """
+    Create prompt to check if the query is self-consistent.
+    """
+
+    prompt = f"""
+    I need to ensure that the user query is self-consistent.
+    This means that the query should be understandable and unambiguous in the
+    context of the system prompt, and the chat history.
+
+    Here is the user query:
+    <<<{query_text}>>>
+
+    Is the user query self-consistent?
+    Reply in a python parsable json with key
+    "consistent" equal to "True" (string) if the query is self-consistent,
+    else "False" (string).
+
+    If "False", provide another key "response" with a brief
+    message explaining why the query is not self-consistent.
+    I will share this response directly with the user. So,
+    make sure the "response" is in {language} and the script
+    is {script}.
+    """
+    return prompt

--- a/askametric/query_processor/guardrails/guardrails_prompts.py
+++ b/askametric/query_processor/guardrails/guardrails_prompts.py
@@ -74,15 +74,15 @@ def create_relevance_prompt(
     return prompt
 
 
-def create_self_consistency_prompt(query_text: str, language: str, script: str) -> str:
+def create_self_consistency_prompt(query_text: str) -> str:
     """
     Create prompt to check if the query is self-consistent.
     """
 
     prompt = f"""
     I need to ensure that the user query is self-consistent.
-    This means that the query should be understandable and unambiguous in the
-    context the chat history -- remember only the semantic meaning of the query matters.
+    This means that the query should be understandable and unambiguous.
+    Remember only the semantic meaning of the query matters.
 
     Here is the user query:
     <<<{query_text}>>>
@@ -94,8 +94,5 @@ def create_self_consistency_prompt(query_text: str, language: str, script: str) 
 
     If "False", provide another key "response" with a brief
     message explaining why the query is not self-consistent.
-    I will share this response directly with the user. So,
-    make sure the "response" is in {language} and the script
-    is {script}.
     """
     return prompt

--- a/askametric/query_processor/query_processing_prompts.py
+++ b/askametric/query_processor/query_processing_prompts.py
@@ -68,8 +68,12 @@ def english_translation_prompt(
     return system_message, prompt
 
 
-def create_reframe_query_prompt(query_text: str, chat_history: list) -> str:
+def create_reframe_query_prompt(query_text: str, chat_history: list) -> tuple[str, str]:
     """Create prompt to reframe the query based on chat history."""
+    sys_message = "You are a highly-skilled linguist.\
+    Your job is to look at the chat history and use it to infer context accurately\
+    to understand what information the user is asking for with the current question."
+
     prompt = f"""
     ===== Question =====
     <<< {query_text} >>>
@@ -81,14 +85,17 @@ def create_reframe_query_prompt(query_text: str, chat_history: list) -> str:
     ===== Reframe question =====
     Is the question clear and unambiguous?
     If yes, you can leave the question as is.
-    If not, reframe the question using information from the chat history. Remember
-    to keep the question as close to the original as possible, and pay more attention
-    to the first questions in the chat history.
+    If not, reframe the question using information from the chat history.
+    REMEMBER:
+    - Keep the question as close to the original as possible, and
+    - Pay more attention to the first question in the chat history.
+    - PAY ATTENTION to words such as "these", "here", "it", etc. in the Question --
+    they refer to places or people in the chat history.
 
     ==== Response format ====
     python parsable json with key "reframed_query".
     """
-    return prompt
+    return sys_message, prompt
 
 
 def create_best_tables_prompt(query_model: dict, table_description: str) -> str:

--- a/askametric/query_processor/query_processing_prompts.py
+++ b/askametric/query_processor/query_processing_prompts.py
@@ -68,7 +68,7 @@ def english_translation_prompt(
     return system_message, prompt
 
 
-def reframe_query_prompt(query_text: str, chat_history: list) -> str:
+def create_reframe_query_prompt(query_text: str, chat_history: list) -> str:
     """Create prompt to reframe the query based on chat history."""
     prompt = f"""
     ===== Question =====

--- a/askametric/query_processor/query_processing_prompts.py
+++ b/askametric/query_processor/query_processing_prompts.py
@@ -68,6 +68,27 @@ def english_translation_prompt(
     return system_message, prompt
 
 
+def reframe_query_prompt(query_text: str, chat_history: list) -> str:
+    """Create prompt to reframe the query based on chat history."""
+    prompt = f"""
+    ===== Question =====
+    <<< {query_text} >>>
+
+    ===== Chat History =====
+    Here is the chat history (might be empty if not available):
+    <<< {chat_history} >>>
+
+    ===== Reframe question =====
+    Is the question clear and unambiguous?
+    If not, reframe the question using the context from the chat history.
+    If yes, you can leave the question as is.
+
+    ==== Response format ====
+    python parsable json with key "reframed_query".
+    """
+    return prompt
+
+
 def create_best_tables_prompt(query_model: dict, table_description: str) -> str:
     """Create prompt for best tables question."""
     prompt = f"""

--- a/askametric/query_processor/query_processing_prompts.py
+++ b/askametric/query_processor/query_processing_prompts.py
@@ -80,8 +80,10 @@ def reframe_query_prompt(query_text: str, chat_history: list) -> str:
 
     ===== Reframe question =====
     Is the question clear and unambiguous?
-    If not, reframe the question using the context from the chat history.
     If yes, you can leave the question as is.
+    If not, reframe the question using information from the chat history. Remember
+    to keep the question as close to the original as possible, and pay more attention
+    to the first questions in the chat history.
 
     ==== Response format ====
     python parsable json with key "reframed_query".

--- a/askametric/query_processor/query_processor.py
+++ b/askametric/query_processor/query_processor.py
@@ -12,7 +12,7 @@ from .query_processing_prompts import (
     get_query_language_prompt,
     create_reframe_query_prompt,
 )
-from .tools import SQLTools, get_tools
+from .tools import SQLTools, get_tools, get_tools_multiturn
 
 
 class LLMQueryProcessor:
@@ -291,7 +291,7 @@ class MultiTurnQueryProcessor(LLMQueryProcessor):
             indicator_vars,
             num_common_values,
         )
-
+        self.tools: SQLTools = get_tools_multiturn()
         self.guardrails: MultiTurnLLMGuardrails = MultiTurnLLMGuardrails(
             guardrails_llm, self.system_message
         )

--- a/askametric/query_processor/tools.py
+++ b/askametric/query_processor/tools.py
@@ -10,6 +10,7 @@ from sqlalchemy.schema import CreateTable
 from ..utils import track_time
 
 _tools_instance = None
+_tools_instance_multiturn = None
 
 
 class SQLTools:
@@ -202,3 +203,11 @@ def get_tools() -> SQLTools:
     if _tools_instance is None:
         _tools_instance = SQLTools()
     return _tools_instance
+
+
+def get_tools_multiturn() -> SQLTools:
+    """Return the SQLTools instance."""
+    global _tools_instance_multiturn
+    if _tools_instance_multiturn is None:
+        _tools_instance_multiturn = SQLTools()
+    return _tools_instance_multiturn

--- a/askametric/utils.py
+++ b/askametric/utils.py
@@ -63,7 +63,6 @@ async def _ask_llm_json(
     system_message: str,
     llm: str = "gpt-4o",
     temperature: float = 0.1,
-    context: str = "",
 ) -> dict:
     """
     A generic function to ask the LLM model a question and return
@@ -79,7 +78,6 @@ async def _ask_llm_json(
         temperature=temperature,
         messages=[
             {"content": system_message, "role": "system"},
-            {"content": context, "role": "assistant"},
             {"content": prompt, "role": "user"},
         ],
         response_format={"type": "json_object"},

--- a/askametric/utils.py
+++ b/askametric/utils.py
@@ -79,10 +79,10 @@ async def _ask_llm_json(
         temperature=temperature,
         messages=[
             {"content": system_message, "role": "system"},
+            {"content": context, "role": "assistant"},
             {"content": prompt, "role": "user"},
         ],
         response_format={"type": "json_object"},
-        context=context,
     )
 
     cost = completion_cost(response)

--- a/askametric/utils.py
+++ b/askametric/utils.py
@@ -63,6 +63,7 @@ async def _ask_llm_json(
     system_message: str,
     llm: str = "gpt-4o",
     temperature: float = 0.1,
+    context: str = "",
 ) -> dict:
     """
     A generic function to ask the LLM model a question and return
@@ -81,6 +82,7 @@ async def _ask_llm_json(
             {"content": prompt, "role": "user"},
         ],
         response_format={"type": "json_object"},
+        context=context,
     )
 
     cost = completion_cost(response)

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,14 +100,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
+      "  return self.__pydantic_serializer__.to_python(\n",
+      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1152}` - serialized value may not be as expected\n",
+      "  return self.__pydantic_serializer__.to_python(\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In Chennai, there are a total of 20,334 beds available. This total is calculated by adding 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. This information is based on the data collected as of May 11.\n"
+      "In Chennai, there are a total of 20,334 beds available. This total comes from two sources: 7,179 beds are from clinics, and 13,155 beds are from health centers and district hospitals. These numbers include beds with and without oxygen supply, as well as ICU beds.\n"
      ]
     }
    ],
@@ -141,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +167,11 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"COVID patients ke baare me batao??\",\n",
+    "    \"query_text\": \"Yahan COVID patients ke baare me batao??\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"Nahin, Ranipet ke liye manga tha\",\n",
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
@@ -163,38 +179,34 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"And how many COVID patients?\",\n",
+    "    \"query_text\": \"And how many COVID patients here?\",\n",
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"Nahin, Ranipur me batao\",\n",
+    "    \"query_text\": \"Nahin, Ranipet ke liye batao\",\n",
     "    \"query_metadata\": {}\n",
     "},]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
-      "  return self.__pydantic_serializer__.to_python(\n",
-      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1152}` - serialized value may not be as expected\n",
-      "  return self.__pydantic_serializer__.to_python(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Q: How many beds are there in chennai??\n",
-      "A: In Chennai, there are a total of 20,334 beds available. This number is the sum of 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. These figures include beds with and without oxygen supply, as well as ICU beds.\n",
+      "A: In Chennai, there are a total of 20,334 beds available. This total comes from two sources: 7,179 beds are from clinics, and 13,155 beds are from health centers and district hospitals. These numbers include beds with and without oxygen supply, as well as ICU beds.\n",
+      "\n",
+      "\n",
+      "Q: How about Ranipet??\n",
+      "A: The availability of beds for COVID-19 patients in Ranipet is as follows: There are 153 vacant beds in clinics and 90 vacant beds in health centers and district hospitals. This information was gathered by checking the current data on bed vacancies specifically for the Ranipet district.\n",
+      "\n",
+      "\n",
+      "Q: Yahan COVID patients ke baare me batao??\n",
+      "A: Tamil Nadu mein COVID-19 ke maamle kuch is prakar hain: Ariyalur mein 624 log ilaaj ke liye hain aur 106 naye maamle aaye hain. Chengalpattu mein 13038 log ilaaj ke liye hain aur 2419 naye maamle aaye hain. Chennai mein 37713 log ilaaj ke liye hain aur 7466 naye maamle aaye hain. Coimbatore mein 14324 log ilaaj ke liye hain aur 2650 naye maamle aaye hain. Is prakar har district ka data ikattha kiya gaya hai. Yeh data 11 May ke liye hai aur ismein naye maamle, discharge hue log aur maut ke maamle shamil hain. Is data ko dekh kar hum samajh sakte hain ki kis district mein kitne maamle hain aur kis tarah se trend chal raha hai.\n",
       "\n",
       "\n"
      ]
@@ -204,7 +216,7 @@
      "output_type": "stream",
      "text": [
       "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1024}` - serialized value may not be as expected\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
       "  return self.__pydantic_serializer__.to_python(\n"
      ]
     },
@@ -212,24 +224,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Q: How about Ranipet??\n",
-      "A: In Ranipet, there are a total of 243 beds available. This number is the sum of 153 vacant beds from clinics and 90 vacant beds from health centers and district hospitals. This information is based on the latest data collected from these facilities.\n",
-      "\n",
-      "\n",
-      "Q: COVID patients ke baare me batao??\n",
-      "A: Tamil Nadu ke COVID patients ke baare mein jaankari yeh hai ki har district mein kitne log treatment mein hain, naye cases, discharge hone wale cases, aur deaths ka data diya gaya hai. Saath hi, har district mein kitne beds khaali hain, yeh bhi bataya gaya hai. Jaise ki, Chennai mein 37,713 log treatment mein hain, 7,466 naye cases hain, 4,583 log discharge ho chuke hain, aur 92 deaths hui hain. Chennai mein 3,472 beds khaali hain. Isi tarah, Coimbatore mein 14,324 log treatment mein hain, 2,650 naye cases hain, 1,723 log discharge ho chuke hain, aur 19 deaths hui hain, aur wahan 276 beds khaali hain. Yeh data 11 May ke liye hai aur har district ka alag-alag data diya gaya hai. Aapko kisi specific district ka data chahiye toh bata sakte hain.\n",
+      "Q: Nahin, Ranipet ke liye manga tha\n",
+      "A: Ranipet ke liye COVID-19 ke maamle aur bed availability ki jaankari yeh hai: 11 May tak 2018 log ilaaj ke liye admit the, aur 11 May ko 423 naye maamle aaye. Us din 277 log discharge hue aur 2 logon ki maut hui. Abhi 2162 log ilaaj ke liye hospital mein hain. Bed availability ki baat karein toh, clinics mein 936 earmarked beds hain jismein se 783 occupied hain aur 153 vacant hain. Health centers aur district hospitals mein 265 earmarked beds with O2 supply hain, 339 without O2 supply, aur 29 ICU beds hain. Inmein se 265 beds with O2 supply, 249 without O2 supply, aur 29 ICU beds occupied hain. Vacant beds ki baat karein toh, O2 supply ke saath koi vacant bed nahi hai, bina O2 supply ke 90 vacant beds hain, aur ICU mein koi vacant bed nahi hai. Total 90 vacant beds hain.\n",
       "\n",
       "\n",
       "Q: How many beds with oxygen supply in Ariyalur??\n",
-      "A: There are 314 beds with oxygen supply available in Ariyalur. This information was obtained from the data collected on bed vacancies in health centers and district hospitals as of May 11th. The number reflects the current capacity for beds equipped with oxygen in the district.\n",
+      "A: There are 314 beds with oxygen supply available in Ariyalur. This information was obtained from the database that tracks bed vacancies in health centers and district hospitals as of May 11th. The data specifically indicates the number of earmarked beds with oxygen supply in the Ariyalur district.\n",
       "\n",
       "\n",
-      "Q: And how many COVID patients?\n",
-      "A: As of the data available for May 11, there are a total of 162,181 COVID patients under treatment in Tamil Nadu. This number was obtained by summing up the reported cases from the database for that specific date.\n",
+      "Q: And how many COVID patients here?\n",
+      "A: Currently, there are 624 COVID patients in Ariyalur. This information was obtained from the data collected on May 11, which tracks the number of persons under treatment in each district.\n",
       "\n",
       "\n",
-      "Q: Nahin, Ranipur me batao\n",
-      "A: Ranipet mein COVID ke 2162 mareez hain. Yeh sankhya 11 May ke data ke adhar par hai, jo ki COVID cases ke record se li gayi hai.\n",
+      "Q: Nahin, Ranipet ke liye batao\n",
+      "A: Ranipet mein filhaal 2162 COVID patients hain. Yeh sankhya humne COVID cases database se prapt ki hai jo 11 May ke data par aadharit hai.\n",
       "\n",
       "\n"
      ]
@@ -257,8 +265,8 @@
     "        )\n",
     "\n",
     "        await mqp.process_query()\n",
-    "        chat_history.append({\"user\": query[\"query_text\"],\n",
-    "                             \"system\": mqp.final_answer})\n",
+    "        chat_history.append({\"user\": mqp.eng_translation[\"query_text\"],\n",
+    "                             \"system\": mqp.translated_answer,})\n",
     "        print(f\"Q: {query['query_text']}\")\n",
     "        print(f\"A: {mqp.final_answer}\")\n",
     "        print(\"\\n\")"

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,25 +73,39 @@
     "- covid_cases_11_may: Each row identifies a district and the number of people who received treatment, were discharged and died due to COVID.\\\n",
     "\"\n",
     "num_common_values = 10\n",
-    "indicator_vars=\"district_name\" # This should be a comma delimited string in multiple vars\n",
-    "\n",
-    "# Your question\n",
-    "query = {\n",
-    "    \"query_text\": \"How many beds are there in chennai??\",\n",
-    "    \"query_metadata\": {}\n",
-    "}"
+    "indicator_vars=\"district_name\" # This should be a comma delimited string in multiple vars\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Single-turn question"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your question\n",
+    "query = {\n",
+    "    \"query_text\": \"How many beds are there in chennai??\",\n",
+    "    \"query_metadata\": {}\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In Chennai, there are a total of 20,334 beds available. This includes 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. The total was calculated by adding the number of earmarked beds from both types of facilities.\n"
+      "In Chennai, there are a total of 20,334 beds available. This total is calculated by adding 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. This information is based on the data collected as of May 11.\n"
      ]
     }
    ],
@@ -114,6 +128,108 @@
     "    )\n",
     "    await qp.process_query()\n",
     "    print(qp.final_answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi-turn chat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulating a conversation\n",
+    "queries = [{\n",
+    "    \"query_text\": \"How many beds are there in chennai??\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"How about Ranipet??\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"And how many COVID patients there??\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"How many beds with oxygen supply in Ariyalur??\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"And how many COVID patients?\",\n",
+    "    \"query_metadata\": {}\n",
+    "},\n",
+    "{\n",
+    "    \"query_text\": \"No I meant in Ranipet\",\n",
+    "    \"query_metadata\": {}\n",
+    "},]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q: How many beds are there in chennai??\n",
+      "A: In Chennai, there are a total of 20,334 beds available. This total is calculated by adding 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. This information is based on the data collected as of May 11.\n",
+      "\n",
+      "\n",
+      "Q: How about Ranipet??\n",
+      "A: In Ranipet, there are a total of 243 vacant beds available. This number is the sum of 153 vacant beds from clinics and 90 vacant beds from health centers and district hospitals. This information is based on the latest data collected from these facilities.\n",
+      "\n",
+      "\n",
+      "Q: And how many COVID patients there??\n",
+      "A: As of the data available for May 11, there are 162,181 COVID patients under treatment in Tamil Nadu. This number was obtained by summing up the total number of persons under treatment on that date from the collected data.\n",
+      "\n",
+      "\n",
+      "Q: How many beds with oxygen supply in Ariyalur??\n",
+      "A: There are 314 beds with oxygen supply available in Ariyalur. This information was obtained from the database that tracks bed vacancies in health centers and district hospitals as of May 11th. The data specifically indicates the number of earmarked beds with oxygen supply in the Ariyalur district.\n",
+      "\n",
+      "\n",
+      "Q: And how many COVID patients?\n",
+      "A: As of the latest available data, there are currently 624 COVID patients in Ariyalur. This information was retrieved from the database, which keeps track of the number of persons under treatment for COVID in each district.\n",
+      "\n",
+      "\n",
+      "Q: No I meant in Ranipet\n",
+      "A: As of the latest data available, there are currently 2,162 COVID patients in Ranipet. This information was retrieved from the database, which keeps track of the number of persons under treatment for COVID-19 in different districts. The specific data point used was the number of persons under treatment on May 11th for the district of Ranipet.\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from askametric.query_processor.query_processor import MultiTurnQueryProcessor\n",
+    "\n",
+    "async with async_session() as session:\n",
+    "    mqp = MultiTurnQueryProcessor(\n",
+    "        asession=session,\n",
+    "        metric_db_id=metric_db_id,\n",
+    "        db_type=db_type,\n",
+    "        llm=llm,\n",
+    "        guardrails_llm=guardrails_llm,\n",
+    "        sys_message=sys_message,\n",
+    "        db_description=db_description,\n",
+    "        column_description=\"\",\n",
+    "        indicator_vars=indicator_vars,\n",
+    "        num_common_values=num_common_values,\n",
+    "        chat_memory_length=5\n",
+    "    )\n",
+    "    results = []\n",
+    "    for query in queries:\n",
+    "        print(f\"Q: {query['query_text']}\")\n",
+    "        result = await mqp.process_query(query)\n",
+    "        results.append(result)\n",
+    "        print(f\"A: {result.final_answer}\")\n",
+    "        print(\"\\n\")"
    ]
   },
   {

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
     "from dotenv import load_dotenv"
    ]
   },
@@ -58,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +155,7 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"And how many COVID patients there??\",\n",
+    "    \"query_text\": \"COVID patients ke baare me batao??\",\n",
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
@@ -165,42 +167,69 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"No I meant in Ranipet\",\n",
+    "    \"query_text\": \"Nahin, Ranipur me batao\",\n",
     "    \"query_metadata\": {}\n",
     "},]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
+      "  return self.__pydantic_serializer__.to_python(\n",
+      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1152}` - serialized value may not be as expected\n",
+      "  return self.__pydantic_serializer__.to_python(\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Q: How many beds are there in chennai??\n",
-      "A: In Chennai, there are a total of 20,334 beds available. This total is calculated by adding 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. This information is based on the data collected as of May 11.\n",
+      "A: In Chennai, there are a total of 20,334 beds available. This number is the sum of 7,179 beds from clinics and 13,155 beds from health centers and district hospitals. These figures include beds with and without oxygen supply, as well as ICU beds.\n",
       "\n",
-      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
+      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1024}` - serialized value may not be as expected\n",
+      "  return self.__pydantic_serializer__.to_python(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Q: How about Ranipet??\n",
-      "A: In Ranipet, there are a total of 243 vacant beds available. This number is the sum of 153 vacant beds from clinics and 90 vacant beds from health centers and district hospitals. This information is based on the latest data collected from these facilities.\n",
+      "A: In Ranipet, there are a total of 243 beds available. This number is the sum of 153 vacant beds from clinics and 90 vacant beds from health centers and district hospitals. This information is based on the latest data collected from these facilities.\n",
       "\n",
       "\n",
-      "Q: And how many COVID patients there??\n",
-      "A: As of the data available for May 11, there are 162,181 COVID patients under treatment in Tamil Nadu. This number was obtained by summing up the total number of persons under treatment on that date from the collected data.\n",
+      "Q: COVID patients ke baare me batao??\n",
+      "A: Tamil Nadu ke COVID patients ke baare mein jaankari yeh hai ki har district mein kitne log treatment mein hain, naye cases, discharge hone wale cases, aur deaths ka data diya gaya hai. Saath hi, har district mein kitne beds khaali hain, yeh bhi bataya gaya hai. Jaise ki, Chennai mein 37,713 log treatment mein hain, 7,466 naye cases hain, 4,583 log discharge ho chuke hain, aur 92 deaths hui hain. Chennai mein 3,472 beds khaali hain. Isi tarah, Coimbatore mein 14,324 log treatment mein hain, 2,650 naye cases hain, 1,723 log discharge ho chuke hain, aur 19 deaths hui hain, aur wahan 276 beds khaali hain. Yeh data 11 May ke liye hai aur har district ka alag-alag data diya gaya hai. Aapko kisi specific district ka data chahiye toh bata sakte hain.\n",
       "\n",
       "\n",
       "Q: How many beds with oxygen supply in Ariyalur??\n",
-      "A: There are 314 beds with oxygen supply available in Ariyalur. This information was obtained from the database that tracks bed vacancies in health centers and district hospitals as of May 11th. The data specifically indicates the number of earmarked beds with oxygen supply in the Ariyalur district.\n",
+      "A: There are 314 beds with oxygen supply available in Ariyalur. This information was obtained from the data collected on bed vacancies in health centers and district hospitals as of May 11th. The number reflects the current capacity for beds equipped with oxygen in the district.\n",
       "\n",
       "\n",
       "Q: And how many COVID patients?\n",
-      "A: As of the latest available data, there are currently 624 COVID patients in Ariyalur. This information was retrieved from the database, which keeps track of the number of persons under treatment for COVID in each district.\n",
+      "A: As of the data available for May 11, there are a total of 162,181 COVID patients under treatment in Tamil Nadu. This number was obtained by summing up the reported cases from the database for that specific date.\n",
       "\n",
       "\n",
-      "Q: No I meant in Ranipet\n",
-      "A: As of the latest data available, there are currently 2,162 COVID patients in Ranipet. This information was retrieved from the database, which keeps track of the number of persons under treatment for COVID-19 in different districts. The specific data point used was the number of persons under treatment on May 11th for the district of Ranipet.\n",
+      "Q: Nahin, Ranipur me batao\n",
+      "A: Ranipet mein COVID ke 2162 mareez hain. Yeh sankhya 11 May ke data ke adhar par hai, jo ki COVID cases ke record se li gayi hai.\n",
       "\n",
       "\n"
      ]
@@ -209,26 +238,29 @@
    "source": [
     "from askametric.query_processor.query_processor import MultiTurnQueryProcessor\n",
     "\n",
+    "chat_history = []\n",
     "async with async_session() as session:\n",
-    "    mqp = MultiTurnQueryProcessor(\n",
-    "        asession=session,\n",
-    "        metric_db_id=metric_db_id,\n",
-    "        db_type=db_type,\n",
-    "        llm=llm,\n",
-    "        guardrails_llm=guardrails_llm,\n",
-    "        sys_message=sys_message,\n",
-    "        db_description=db_description,\n",
-    "        column_description=\"\",\n",
-    "        indicator_vars=indicator_vars,\n",
-    "        num_common_values=num_common_values,\n",
-    "        chat_memory_length=5\n",
-    "    )\n",
-    "    results = []\n",
     "    for query in queries:\n",
+    "        mqp = MultiTurnQueryProcessor(\n",
+    "            query=query,\n",
+    "            asession=session,\n",
+    "            metric_db_id=metric_db_id,\n",
+    "            db_type=db_type,\n",
+    "            llm=llm,\n",
+    "            guardrails_llm=guardrails_llm,\n",
+    "            sys_message=sys_message,\n",
+    "            db_description=db_description,\n",
+    "            column_description=\"\",\n",
+    "            indicator_vars=indicator_vars,\n",
+    "            num_common_values=num_common_values,\n",
+    "            chat_history=chat_history\n",
+    "        )\n",
+    "\n",
+    "        await mqp.process_query()\n",
+    "        chat_history.append({\"user\": query[\"query_text\"],\n",
+    "                             \"system\": mqp.final_answer})\n",
     "        print(f\"Q: {query['query_text']}\")\n",
-    "        result = await mqp.process_query(query)\n",
-    "        results.append(result)\n",
-    "        print(f\"A: {result.final_answer}\")\n",
+    "        print(f\"A: {mqp.final_answer}\")\n",
     "        print(\"\\n\")"
    ]
   },

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -69,12 +69,16 @@
     "llm = \"gpt-4o\"\n",
     "validation_llm = \"gpt-4o\"\n",
     "guardrails_llm = \"gpt-4o\"\n",
+    "\n",
     "sys_message = \"Government and health officials in Tamil Nadu, India will ask you questions. You need to help them manage COVID cases and the availablity of beds in health facilities.\"\n",
+    "\n",
     "db_description = \"- bed_vacancies_clinics_11_may: Each row identifies a district and the beds earmarked, occupied and available for COVID cases in the district clinics.\\\n",
     "- bed_vacancies_health_centers_and_district_hospitals_11_may: Each row identifies a district and the beds earmarked, occupied and available, with and without oxygen supply, and with and without ICU support, for COVID cases in the disctrict health centers and hospitals.\\\n",
     "- covid_cases_11_may: Each row identifies a district and the number of people who received treatment, were discharged and died due to COVID.\\\n",
     "\"\n",
+    "\n",
     "num_common_values = 10\n",
+    "\n",
     "indicator_vars=\"district_name\" # This should be a comma delimited string in multiple vars\n"
    ]
   },
@@ -87,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,26 +104,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
-      "  return self.__pydantic_serializer__.to_python(\n",
-      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 1152}` - serialized value may not be as expected\n",
-      "  return self.__pydantic_serializer__.to_python(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In Chennai, there are a total of 20,334 beds available. This total comes from two sources: 7,179 beds are from clinics, and 13,155 beds are from health centers and district hospitals. These numbers include beds with and without oxygen supply, as well as ICU beds.\n"
+      "In Chennai, there are a total of 20,334 beds available. This total is derived from two sources: 7,179 beds are available in clinics, and 13,155 beds are available in health centers and district hospitals. These numbers represent the sum of earmarked beds, including those with and without oxygen supply, as well as ICU beds.\n"
      ]
     }
    ],
@@ -158,6 +150,7 @@
    "outputs": [],
    "source": [
     "# Simulating a conversation\n",
+    "\n",
     "queries = [{\n",
     "    \"query_text\": \"How many beds are there in chennai??\",\n",
     "    \"query_metadata\": {}\n",
@@ -167,11 +160,7 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"Yahan COVID patients ke baare me batao??\",\n",
-    "    \"query_metadata\": {}\n",
-    "},\n",
-    "{\n",
-    "    \"query_text\": \"Nahin, Ranipet ke liye manga tha\",\n",
+    "    \"query_text\": \"Inge irrukira COVID patients patthi sollu\",\n",
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
@@ -183,14 +172,14 @@
     "    \"query_metadata\": {}\n",
     "},\n",
     "{\n",
-    "    \"query_text\": \"Nahin, Ranipet ke liye batao\",\n",
+    "    \"query_text\": \"Nahin, Ariyalur ke liye batao\",\n",
     "    \"query_metadata\": {}\n",
-    "},]"
+    "},]\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -198,34 +187,15 @@
      "output_type": "stream",
      "text": [
       "Q: How many beds are there in chennai??\n",
-      "A: In Chennai, there are a total of 20,334 beds available. This total comes from two sources: 7,179 beds are from clinics, and 13,155 beds are from health centers and district hospitals. These numbers include beds with and without oxygen supply, as well as ICU beds.\n",
+      "A: In Chennai, there are a total of 20,334 beds available. This total is derived from two sources: 7,179 beds are available in clinics, and 13,155 beds are available in health centers and district hospitals. These numbers represent the sum of earmarked beds, including those with and without oxygen supply, as well as ICU beds.\n",
       "\n",
       "\n",
       "Q: How about Ranipet??\n",
-      "A: The availability of beds for COVID-19 patients in Ranipet is as follows: There are 153 vacant beds in clinics and 90 vacant beds in health centers and district hospitals. This information was gathered by checking the current data on bed vacancies specifically for the Ranipet district.\n",
+      "A: In Ranipet, there are a total of 1,569 beds available. This total is calculated by adding 936 beds from clinics and 633 beds from health centers and district hospitals. This includes beds with and without oxygen supply, as well as ICU beds.\n",
       "\n",
       "\n",
-      "Q: Yahan COVID patients ke baare me batao??\n",
-      "A: Tamil Nadu mein COVID-19 ke maamle kuch is prakar hain: Ariyalur mein 624 log ilaaj ke liye hain aur 106 naye maamle aaye hain. Chengalpattu mein 13038 log ilaaj ke liye hain aur 2419 naye maamle aaye hain. Chennai mein 37713 log ilaaj ke liye hain aur 7466 naye maamle aaye hain. Coimbatore mein 14324 log ilaaj ke liye hain aur 2650 naye maamle aaye hain. Is prakar har district ka data ikattha kiya gaya hai. Yeh data 11 May ke liye hai aur ismein naye maamle, discharge hue log aur maut ke maamle shamil hain. Is data ko dekh kar hum samajh sakte hain ki kis district mein kitne maamle hain aur kis tarah se trend chal raha hai.\n",
-      "\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/poornima/.cache/pypoetry/virtualenvs/askametric-JOXIZc-T-py3.11/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:\n",
-      "  Expected `PromptTokensDetails` but got `dict` with value `{'audio_tokens': None, 'cached_tokens': 0}` - serialized value may not be as expected\n",
-      "  return self.__pydantic_serializer__.to_python(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Q: Nahin, Ranipet ke liye manga tha\n",
-      "A: Ranipet ke liye COVID-19 ke maamle aur bed availability ki jaankari yeh hai: 11 May tak 2018 log ilaaj ke liye admit the, aur 11 May ko 423 naye maamle aaye. Us din 277 log discharge hue aur 2 logon ki maut hui. Abhi 2162 log ilaaj ke liye hospital mein hain. Bed availability ki baat karein toh, clinics mein 936 earmarked beds hain jismein se 783 occupied hain aur 153 vacant hain. Health centers aur district hospitals mein 265 earmarked beds with O2 supply hain, 339 without O2 supply, aur 29 ICU beds hain. Inmein se 265 beds with O2 supply, 249 without O2 supply, aur 29 ICU beds occupied hain. Vacant beds ki baat karein toh, O2 supply ke saath koi vacant bed nahi hai, bina O2 supply ke 90 vacant beds hain, aur ICU mein koi vacant bed nahi hai. Total 90 vacant beds hain.\n",
+      "Q: Inge irrukira COVID patients patthi sollu\n",
+      "A: Ranipet-il COVID manithargal patri ketkirirgal. Angu irukkum data padi, Ranipet-il 2018 COVID manithargal irukkirargal. Ivaril 423 per maruthuvamanaiyil irukkirargal, 277 per maruthuvamanaiyil irundhu viduvikkappattirargal, 2 per maranam adainthirargal. Ithu thavira, 2162 per COVID-ai anubavithu maruthuvamanaiyil irundhu viduvikkappattirargal. Itha data-il irundhu eduththom.\n",
       "\n",
       "\n",
       "Q: How many beds with oxygen supply in Ariyalur??\n",
@@ -233,11 +203,11 @@
       "\n",
       "\n",
       "Q: And how many COVID patients here?\n",
-      "A: Currently, there are 624 COVID patients in Ariyalur. This information was obtained from the data collected on May 11, which tracks the number of persons under treatment in each district.\n",
+      "A: As of the data collected on 11th May, there are 37,713 COVID patients in Chennai. This number was obtained from the records that track the number of persons under treatment for COVID in different districts, specifically for Chennai.\n",
       "\n",
       "\n",
-      "Q: Nahin, Ranipet ke liye batao\n",
-      "A: Ranipet mein filhaal 2162 COVID patients hain. Yeh sankhya humne COVID cases database se prapt ki hai jo 11 May ke data par aadharit hai.\n",
+      "Q: Nahin, Ariyalur ke liye batao\n",
+      "A: Ariyalur mein COVID ke 624 mareez hain. Yeh sankhya 11 May ke data ke adhar par hai, jo humare database se prapt hui hai.\n",
       "\n",
       "\n"
      ]
@@ -263,10 +233,9 @@
     "            num_common_values=num_common_values,\n",
     "            chat_history=chat_history\n",
     "        )\n",
-    "\n",
     "        await mqp.process_query()\n",
     "        chat_history.append({\"user\": mqp.eng_translation[\"query_text\"],\n",
-    "                             \"system\": mqp.translated_answer,})\n",
+    "                             \"system\": mqp.translated_answer})\n",
     "        print(f\"Q: {query['query_text']}\")\n",
     "        print(f\"A: {mqp.final_answer}\")\n",
     "        print(\"\\n\")"


### PR DESCRIPTION
Reviewer: @ziakhan04 @suzinyou 

Estimate: ~5 mins - 30 mins depending on how much you want to test

---

### Goal
Version 2 of multi-turn. 
(Previous version overwrote the original pipeline, and was trying to do too many things: summarize, resolve guardrails, etc.). 
In this version, multi-turn is a separate query processing class, I added 1 extra guardrail, and reframe ambiguous questions instead of summarizing chat history. 

### Changes
I'm too lazy to type, and I like excalidraw too much, so here's what multi-turn pipeline looks like:
![multi-turn-pipeline(1)](https://github.com/user-attachments/assets/f7d0bf5a-d815-4e8e-95be-8260aabd2560)


### How has this been tested?
Run the multi-turn section in the `demo.ipynb`. You can also add questions or try with another db.

### TODOs / other things to think about:
- This PR just implements short term memory (we keep a running log of the chat history in RAM and pass it back to the query processor) but we could store all chat interactions as long-term memory and use it to learn chat patterns, fine-tune the LLM etc., but not sure how best to do this yet.
- Right now, the LLM infers context in multi-turn only if the question has specific connecting words: e.g. if you ask “How many beds in Ariyalur?” and then “How about COVID-19 patients?” results in information for the whole of Tamil Nadu, but if you ask “How about COVId-19 patients here?“ then you get info specific to Ariyalur. I guess this level of brittleness is to be expected, but not easy to fix unless we learn question/language patterns for each user and/or session, and needs more thinking to resolve.
- Need to do experiments with varying context length -- 5 seems to work well, 1 is ok right now, unless one of the questions triggers a guardrail.
- For the future, we could include sub-pipeline that determines whether the answer can be generated from the chat history, so we can be more efficient and not re-run the pipeline unnescessarily
- Right now caching for single- and multi-turn are separated, but repeated questions in multi-turn should likely not be answered from the cache in case the chat history is different -- might have to think about conditional caching.
- I tested multi-turn with the TN COVID and Morocco Afrobarometer DB, should do more extensive testing with other DBs

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated affected documentation (if applicable)
