### PR TITLE
make column description optional

### DIFF
--- a/askametric/query_processor/db_descriptor/description_generator.py
+++ b/askametric/query_processor/db_descriptor/description_generator.py
@@ -94,7 +94,7 @@ class DatabaseDescriptor:
         metric_db_id: str,
         sys_message: str,
         table_description: str,
-        column_description: str = "",
+        column_description: str | None = None,
     ) -> str:
         """
         Generate suggested questions based on the database description.
@@ -116,7 +116,7 @@ class DatabaseDescriptor:
                 system_prompt=sys_message,
                 tables_description=table_description,
                 db_schema=db_schema,
-                column_description=column_description,
+                column_description=column_description or "",
             )
             generated_questions = await _ask_llm_json(
                 prompt=prompt,


### PR DESCRIPTION
Reviewer: @ziakhan04 

Estimate: 5 minutes

---

### Goal

Column descriptions should be optional when generationg suggested questions

### Changes

Make it optional. If it's None, feed in empty string.

## How has this been tested?

Tested manually

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
