### PR TITLE
Support optional API key for LLM calls

### DIFF
--- a/askametric/query_processor/db_descriptor/description_generator.py
+++ b/askametric/query_processor/db_descriptor/description_generator.py
@@ -46,6 +46,7 @@ class DatabaseDescriptor:
         sys_message: str,
         table_description: str,
         column_description: str = "",
+        api_key: str | None = None,
     ) -> str:
         """
         Generate a database description.
@@ -56,6 +57,7 @@ class DatabaseDescriptor:
             table_description: The description of the table in the database.
             column_description: The description of the columns in the table.
                 Defaults to None.
+            api_key: (Optional) API key to use for the LLM call
         """
         if metric_db_id not in self._description_cache["db_description"]:
             tables_list = [row["name"] for row in json.loads(table_description)]
@@ -74,6 +76,7 @@ class DatabaseDescriptor:
                 system_message=system,
                 llm=self.llm,
                 temperature=self.temperature,
+                api_key=api_key,
             )
             self.logger.debug(
                 f"Generated description for {metric_db_id}: {generated_description}"
@@ -95,6 +98,7 @@ class DatabaseDescriptor:
         sys_message: str,
         table_description: str,
         column_description: str | None = None,
+        api_key: str | None = None,
     ) -> str:
         """
         Generate suggested questions based on the database description.
@@ -105,6 +109,7 @@ class DatabaseDescriptor:
             table_description: The description of the table in the database.
             column_description: The description of the columns in the table.
                 Defaults to None.
+            api_key: (Optional) API key to use for the LLM call
         """
         if metric_db_id not in self._description_cache["suggested_questions"]:
             tables_list = [row["name"] for row in json.loads(table_description)]
@@ -123,6 +128,7 @@ class DatabaseDescriptor:
                 system_message=system,
                 llm=self.llm,
                 temperature=self.temperature,
+                api_key=api_key,
             )
             self.logger.debug(
                 f"Generated questions for {metric_db_id}:{generated_questions}"

--- a/askametric/query_processor/guardrails/guardrails.py
+++ b/askametric/query_processor/guardrails/guardrails.py
@@ -41,14 +41,20 @@ class LLMGuardRails:
         self.safety_response = ""
         self.relevance_response = ""
 
-    async def check_safety(self, query: str, language: str, script: str) -> dict:
+    async def check_safety(
+        self, query: str, language: str, script: str, api_key: str | None
+    ) -> dict:
         """
         Handle the PII in the query.
         """
         prompt = create_safety_prompt(query, language, script)
         self.logger.debug(f"(Guardrail Prompt) Safety: {prompt}")
         safety_response = await ask_llm_json(
-            prompt, self.system_message, self.guardrails_llm, self.temperature
+            prompt,
+            self.system_message,
+            self.guardrails_llm,
+            self.temperature,
+            api_key=api_key,
         )
         self.safe = safety_response["answer"]["safe"] == "True"
         if self.safe is False:
@@ -61,7 +67,12 @@ class LLMGuardRails:
         return safety_response
 
     async def check_relevance(
-        self, query: str, language: str, script: str, table_description: str
+        self,
+        query: str,
+        language: str,
+        script: str,
+        table_description: str,
+        api_key: str | None = None,
     ) -> dict:
         """
         Handle the relevance of the query.
@@ -71,7 +82,11 @@ class LLMGuardRails:
         )
         self.logger.debug(f"(Guardrail Prompt) Relevance: {prompt}")
         relevance_response = await ask_llm_json(
-            prompt, self.system_message, self.guardrails_llm, self.temperature
+            prompt,
+            self.system_message,
+            self.guardrails_llm,
+            self.temperature,
+            api_key=api_key,
         )
         self.relevant = relevance_response["answer"]["relevant"] == "True"
         if self.relevant is False:

--- a/askametric/utils.py
+++ b/askametric/utils.py
@@ -67,6 +67,7 @@ async def ask_llm_json(
     system_message: str,
     llm: str = "gpt-4o",
     temperature: float = 0.1,
+    api_key: str | None = None,
 ) -> dict:
     """
     A generic function to ask the LLM model a question and return
@@ -85,6 +86,7 @@ async def ask_llm_json(
             {"content": prompt, "role": "user"},
         ],
         response_format={"type": "json_object"},
+        api_key=api_key,
     )
 
     cost = completion_cost(response)

--- a/askametric/validation/validation_processor.py
+++ b/askametric/validation/validation_processor.py
@@ -38,7 +38,11 @@ class QueryEvaluator:
         }
 
     async def test_relevancy(
-        self, question: str, llm_response: str, **kwargs: Any
+        self,
+        question: str,
+        llm_response: str,
+        api_key: str | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         relevancy_prompt = get_relevancy_prompt(
             question=question, llm_response=llm_response
@@ -48,6 +52,7 @@ class QueryEvaluator:
             prompt=relevancy_prompt,
             llm=self.llm,
             temperature=self.temperature,
+            api_key=api_key,
         )
         relevancy_evaluation = relevancy_evaluation["answer"]
 
@@ -61,13 +66,17 @@ class QueryEvaluator:
         llm_response: str,
         llm_ided_script: str,
         llm_ided_language: str,
+        api_key: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         accuracy_prompt = get_accuracy_prompt(
             correct_answer=correct_answer, llm_response=llm_response
         )
         accuracy_evaluation = await ask_llm_json(
-            system_message=self.grading_bot_prompt, prompt=accuracy_prompt, llm=self.llm
+            system_message=self.grading_bot_prompt,
+            prompt=accuracy_prompt,
+            llm=self.llm,
+            api_key=api_key,
         )
         accuracy_evaluation = accuracy_evaluation["answer"]
 
@@ -115,7 +124,12 @@ class QueryEvaluator:
         return schema_evaluation
 
     async def test_instructions(
-        self, question: str, llm_response: str, instructions: str, **kwargs: Any
+        self,
+        question: str,
+        llm_response: str,
+        instructions: str,
+        api_key: str | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         instructions_prompt = get_instructions_prompt(
             question=question, instructions=instructions, llm_response=llm_response
@@ -125,12 +139,17 @@ class QueryEvaluator:
             prompt=instructions_prompt,
             llm=self.llm,
             temperature=self.temperature,
+            api_key=api_key,
         )
         instructions_evaluation = instructions_evaluation["answer"]
         return {f"instructions_{k}": val for k, val in instructions_evaluation.items()}
 
     async def test_consistency(
-        self, question: str, llm_response: str, **kwargs: Any
+        self,
+        question: str,
+        llm_response: str,
+        api_key: str | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         """
         Check if the LLM response is in a consistent format with the question
@@ -143,6 +162,7 @@ class QueryEvaluator:
             prompt=consistency_prompt,
             llm=self.llm,
             temperature=self.temperature,
+            api_key=api_key,
         )
         consistency_evaluation = consistency_evaluation["answer"]
         return {f"consistency_{k}": val for k, val in consistency_evaluation.items()}


### PR DESCRIPTION
Reviewer: @ziakhan04 

Estimate: 10 minutes

---

### Goal

Give the option for users to pass API keys to AAM functions, instead of relying only on the environment variable

### Changes

- Optional `api_key: str | None = None` param for all public class functions that eventually call LLM
- If `api_key=None`, litellm automatically reads from env var
- Applied to: query processors, guardrails, and validation tools

## How has this been tested?

Ran test notebooks

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts